### PR TITLE
add start_time end_time to contract and remove duration

### DIFF
--- a/db/migrate/20171017023644_add_start_end_to_contracts.rb
+++ b/db/migrate/20171017023644_add_start_end_to_contracts.rb
@@ -1,0 +1,6 @@
+class AddStartEndToContracts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :contracts, :start_time, :datetime
+    add_column :contracts, :end_time, :datetime
+  end
+end

--- a/db/migrate/20171017024021_remove_duration_from_contracts.rb
+++ b/db/migrate/20171017024021_remove_duration_from_contracts.rb
@@ -1,0 +1,5 @@
+class RemoveDurationFromContracts < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :contracts, :duration, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171016072344) do
+ActiveRecord::Schema.define(version: 20171017024021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "contracts", force: :cascade do |t|
-    t.datetime "duration"
     t.integer "price"
     t.bigint "user_id"
     t.bigint "equipment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.index ["equipment_id"], name: "index_contracts_on_equipment_id"
     t.index ["user_id"], name: "index_contracts_on_user_id"
   end


### PR DESCRIPTION
Create migration file to add start_time, end_time column and remove duration column in Contract model.